### PR TITLE
[dist] Add `chalk` as dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -236,7 +236,6 @@
       "version": "3.2.1",
       "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
-      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -668,9 +667,8 @@
     },
     "chalk": {
       "version": "2.4.2",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
-      "dev": true,
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -822,7 +820,6 @@
       "version": "1.9.3",
       "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -830,8 +827,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "combined-stream": {
       "version": "1.0.7",
@@ -1281,8 +1277,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eslint": {
       "version": "5.13.0",
@@ -2091,8 +2086,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-symbol-support-x": {
       "version": "1.4.2",
@@ -5258,9 +5252,8 @@
     },
     "supports-color": {
       "version": "5.5.0",
-      "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
-      "dev": true,
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "requires": {
         "has-flag": "^3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "license": "ISC",
   "dependencies": {
     "aws-sdk": "^2.400.0",
-    "bluebird": "^3.5.3"
+    "bluebird": "^3.5.3",
+    "chalk": "^2.4.2"
   },
   "devDependencies": {
     "chai": "^4.2.0",


### PR DESCRIPTION
`chalk` was used in #15 but never added as a dependency. So this breaks consumers now.