### PR TITLE
[feat] allow targetting SC template name instead of ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ provider:
   runtime: python2.7
   stage: dev
   deploymentBucket: [deploymentbucket]
-  scProductId: [serverlessProductId]
+  scProductId: [serverlessProductId] # Or use scProductName instead if you want to target your template's name
   scProductVersion: [serverlessProvisioningArtifactNames]
   region: us-east-1
   tags:

--- a/test/aws-compile-service-catalog.test.js
+++ b/test/aws-compile-service-catalog.test.js
@@ -183,5 +183,40 @@ describe('AwsCompileFunctions', () => {
           expect(securityParam.Value).to.equal('arn:aws:xxx:*:*');
         });
     });
+
+    it('should use scProductId when present', () => {
+      setup({
+        scProductName: 'foo'
+      });
+      return expect(awsCompileServiceCatalog.compileFunctions()).to.be.fulfilled
+        .then(() => {
+          const functionResource = awsCompileServiceCatalog.serverless.service.provider
+            .compiledCloudFormationTemplate.Resources[productNameHello];
+          expect(functionResource.Properties.ProductId).to.equal('prod-testid');
+          expect(functionResource.Properties.ProductName).to.not.exist;
+        });
+    });
+
+    it('should use scProductName when present and no scProductId is specified', () => {
+      setup({
+        scProductId: void 0,
+        scProductName: 'foo'
+      });
+      return expect(awsCompileServiceCatalog.compileFunctions()).to.be.fulfilled
+        .then(() => {
+          const functionResource = awsCompileServiceCatalog.serverless.service.provider
+            .compiledCloudFormationTemplate.Resources[productNameHello];
+          expect(functionResource.Properties.ProductId).to.not.exist;
+          expect(functionResource.Properties.ProductName).to.equal('foo');
+        });
+    });
+
+    it('should reject when neither scProductId nor scProductName are specified', () => {
+      setup({
+        scProductId: void 0
+      });
+      return expect(awsCompileServiceCatalog.compileFunctions())
+        .to.be.rejectedWith('Missing scProductId or scProductName on service.');
+    });
   });
 });


### PR DESCRIPTION
It's a pain to have to target service catalog template IDs as they're different per account/region. [AWS CloudFormation docs explain](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-servicecatalog-cloudformationprovisionedproduct.html#cfn-servicecatalog-cloudformationprovisionedproduct-productname) that you can pass in the product template name instead of ID.

So this PR adds support to choose to use name instead. We'll still use ID if it's specified, but if it is not and name is, we'll use that instead.