### PR TITLE
[feat] Allow for ServiceCatalog parameter renaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,3 +163,33 @@ LambdaLayers:
   Description: "(optional) list of lambda layers for the function"
   Default: ""
 ```
+
+## Using Custom Service Catalog Parameter Names
+
+If you already have a service catalog product for Lambdas that has a different naming schema, you can still use that product. You can provide a renaming mapping in your `serverless.yml` file like so:
+
+```yaml
+provider:
+  scParameterMapping:
+    stage: SomeCustomStageName
+    name: MyLambdaParameterName
+```
+
+You can specify any of the following properties to be renamed (shown here with their default values):
+
+```yaml
+provider:
+  scParameterMapping:
+    s3Bucket: S3Bucket
+    s3Key: S3Key
+    handler: Handler
+    name: LambdaName
+    memorySize: MemorySize
+    timeout: Timeout
+    runtime: Runtime
+    stage: LambdaStage
+    environmentVariablesJson: EnvironmentVariablesJson
+    vpcSecurityGroups: VpcSecurityGroups
+    vpcSubnetIds: VpcSubnetIds
+    lambdaLayers: LambdaLayers
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -305,6 +305,52 @@
       "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
       "dev": true
     },
+    "@sinonjs/commons": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.1.tgz",
+      "integrity": "sha512-Debi3Baff1Qu1Unc3mjJ96MgpbwTn43S1+9yJ0llWygPwDNu2aaWBD6yc9y/Z8XDRNhx7U+u2UDg2OGQXkclUQ==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.0.tgz",
+      "integrity": "sha512-atR1J/jRXvQAb47gfzSK8zavXy7BcpnYq21ALon0U99etu99vsir0trzIO3wpeLtW+LLVY6X7EkfVTbjGSH8Ww==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-5.0.1.tgz",
+      "integrity": "sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^5.0.2"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.0.2.tgz",
+      "integrity": "sha512-p3yrEVB5F/1wI+835n+X8llOGRgV8+jw5BHQ/cJoLBUXXZ5U8Tr5ApwPc4L4av/vjla48kVPoN0t6dykQm+Rvg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.6.0",
+        "@sinonjs/formatio": "^5.0.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
     "@szmarczak/http-timer": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
@@ -3623,6 +3669,12 @@
         "set-immediate-shim": "~1.0.1"
       }
     },
+    "just-extend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+      "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
+      "dev": true
+    },
     "jwt-decode": {
       "version": "2.2.0",
       "resolved": "https://artifactory.secureserver.net/artifactory/api/npm/node-virt/jwt-decode/-/jwt-decode-2.2.0.tgz",
@@ -3773,6 +3825,12 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+      "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
     "log-symbols": {
@@ -4166,6 +4224,37 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "nise": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-4.0.2.tgz",
+      "integrity": "sha512-ALDnm0pTTyeGdbg5FCpWGd58Nmp3qO8d8x+dU2Fw8lApeJTEBSjkBZZM4S8t6GpKh+czxkfM/TKxpRMroZzwOg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/fake-timers": "^6.0.0",
+        "@sinonjs/formatio": "^5.0.1",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "dev": true,
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
     },
     "node-dir": {
       "version": "0.1.17",
@@ -5352,6 +5441,44 @@
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
+          }
+        }
+      }
+    },
+    "sinon": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.0.0.tgz",
+      "integrity": "sha512-c4bREcvuK5VuEGyMW/Oim9I3Rq49Vzb0aMdxouFaA44QCFpilc5LJOugrX+mkrvikbqCimxuK+4cnHVNnLR41g==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/fake-timers": "^6.0.0",
+        "@sinonjs/formatio": "^5.0.0",
+        "@sinonjs/samsam": "^5.0.1",
+        "diff": "^4.0.2",
+        "nise": "^4.0.1",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "test": "mocha",
     "test-coverage": "nyc --reporter=lcov mocha",
+    "posttest": "npm run lint",
     "lint": "eslint . --cache"
   },
   "repository": {
@@ -41,6 +42,7 @@
     "eslint-plugin-mocha": "^5.3.0",
     "mocha": "^6.2.2",
     "nyc": "^14.1.1",
-    "serverless": "^1.55.1"
+    "serverless": "^1.55.1",
+    "sinon": "^9.0.0"
   }
 }

--- a/test/customTestTemplate-NoStage.json
+++ b/test/customTestTemplate-NoStage.json
@@ -1,0 +1,45 @@
+{
+  "Type": "AWS::ServiceCatalog::CloudFormationProvisionedProduct",
+
+  "Properties": {
+    "ProvisioningParameters": [
+      {
+        "Key": "S3Bucket",
+        "Value": "ServerlessDeploymentBucket"
+      },
+      {
+        "Key": "S3Key",
+        "Value": "S3Key"
+      },
+      {
+        "Key": "LambdaName",
+        "Value": "LambdaName"
+      },
+      {
+        "Key": "Handler",
+        "Value": "Handler"
+      },
+      {
+        "Key": "Runtime",
+        "Value": "Runtime"
+      },
+      {
+        "Key": "MemorySize",
+        "Value": "MemorySize"
+      },
+      {
+        "Key": "Timeout",
+        "Value": "Timeout"
+      },
+      { 
+        "Key": "CustomParam",
+        "Value": "CustomValue"
+      }
+    ],
+    "ProvisioningArtifactName": "ProvisioningArtifactName",
+    "ProductId": "ProductId",
+    "ProvisionedProductName": {
+      "Fn::Sub": "provisionServerless-${LambdaName}"
+    }
+  }
+}

--- a/test/customTestTemplate.json
+++ b/test/customTestTemplate.json
@@ -1,0 +1,49 @@
+{
+  "Type": "AWS::ServiceCatalog::CloudFormationProvisionedProduct",
+
+  "Properties": {
+    "ProvisioningParameters": [
+      {
+        "Key": "CustomS3Bucket",
+        "Value": "ServerlessDeploymentBucket"
+      },
+      {
+        "Key": "CustomS3Key",
+        "Value": "S3Key"
+      },
+      {
+        "Key": "CustomLambdaName",
+        "Value": "LambdaName"
+      },
+      {
+        "Key": "CustomLambdaStage",
+        "Value": "test"
+      },
+      {
+        "Key": "CustomHandler",
+        "Value": "Handler"
+      },
+      {
+        "Key": "CustomRuntime",
+        "Value": "Runtime"
+      },
+      {
+        "Key": "CustomMemorySize",
+        "Value": "MemorySize"
+      },
+      {
+        "Key": "CustomTimeout",
+        "Value": "Timeout"
+      },
+      { 
+        "Key": "CustomCustomParam",
+        "Value": "CustomValue"
+      }
+    ],
+    "ProvisioningArtifactName": "ProvisioningArtifactName",
+    "ProductId": "ProductId",
+    "ProvisionedProductName": {
+      "Fn::Sub": "provisionServerless-${LambdaName}"
+    }
+  }
+}


### PR DESCRIPTION
Fixes Issue #7 (Allow mapping Serverless parameters to ServiceCatalog templates).

With this npm-linked, I was able to create some Lambdas based on a different product catalog product that doesn't match identically.  And with a different `template.json` file I could also do the following and drop parameters altogether (the product I'm working with doesn't have a stage parameter at all):

```yaml
provider:
  scProductMapping:
    stage: ''
```

I could maybe add that in a more full featured manner and try to splice out the keys from the default product template data, but 🤷‍♂ 

Closes #7 